### PR TITLE
Submodule support

### DIFF
--- a/install.js
+++ b/install.js
@@ -4,17 +4,28 @@ var fs = require('fs'),
 var existsSync = fs.existsSync || path.existsSync;
 
 var projectPath = path.resolve(__dirname, '../../'),
+		projectName = path.basename(projectPath),
     filePath = path.join(__dirname, 'files'),
     pcPath = path.join(projectPath, '.git', 'hooks', 'pre-commit'),
     jsiPath = path.join(projectPath, '.jshintignore'),
-    jsrcPath = path.join(projectPath, '.jshintrc');
+    jsrcPath = path.join(projectPath, '.jshintrc'),
+		pcModulePath = path.join(projectPath, '../', '.git', 'modules', projectName, 'hooks');
 
-if (existsSync(path.join(projectPath, '.git'))) {
+var stats = fs.lstatSync(path.join(projectPath, '.git'));
+
+if (stats.isDirectory() && existsSync(path.join(projectPath, '.git'))) {
     if (existsSync(pcPath)) fs.unlinkSync(pcPath);
     console.log('Found .git directory, adding pre-commit hook');
     var pcHook = fs.readFileSync(path.join(filePath, 'pre-commit'));
     fs.writeFileSync(pcPath, pcHook);
     fs.chmodSync(pcPath, '755');
+} else if (existsSync(pcModulePath)){
+
+	console.log('Found submodule .git directory, adding pre-commit hook');
+	var pcHook = fs.readFileSync(path.join(filePath, 'pre-commit'));
+	var pcModuleFullPath = path.join(pcModulePath, 'pre-commit');
+	fs.writeFileSync(pcModuleFullPath, pcHook);
+	fs.chmodSync(pcModuleFullPath, '755');
 }
 
 if (!existsSync(jsiPath)) {


### PR DESCRIPTION
Not sure how helpful this is to others, but I have a project with submodules and wanted to add a precommit hook to one of the submodules. This falls back to looking for the module hooks directory if it detects the .git link is a file and not a directory.
