### PR TITLE
Trailing Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "uninstall": "hook_uninstall"
   },
   "peerDependencies": {
-    "jshint": "^2.4.4"
+    "jshint": "~2.4.4"
   }
 }


### PR DESCRIPTION
https://github.com/jshint/jshint/commit/0c0e19319b276b019d285bdfd2cfc49126abd814

The trailing option has been removed from jshint version >= 2.5.0. This pull request will pin jshint to any 2.4.x version.
