### PR TITLE
treat `notfound` as an error if it applies to an explicitly-specified script

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -10,7 +10,6 @@ var ok = '\x1B[32mok\x1B[39m';
 var notfound = '\x1B[31mfailed\x1B[31m (no script found)';
 var notfoundDefault = '\x1B[33mn/a\x1B[39m (no script found)';
 
-
 // longest name, for padding
 var longest = 0;
 


### PR DESCRIPTION
The current hook prints a warning if a script does not exist but does not prevent the commit from happening.

This makes sense if the script that is not found is one of the default `validate` or `test` scripts added when one does not specify what scripts should be run by the hook.

However, if you explicitly specify `foo` and `scripts.foo` is something that does not exist, this should (IMO, anyway) be an error.

So, that's what this PR does.
