### PR TITLE
correct comment

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -13,7 +13,7 @@ exports.findGitRoot = function (callback) {
 };
 
 // traverse from this module's directory upwards until you find
-// the project root, which is the first directory whose parent is
+// the project root, which is the first directory
 // *not* named node_modules
 exports.findProjectRoot = function (base) {
     base = base || __dirname;


### PR DESCRIPTION
Function returns first dir it finds not named `node_modules` but comment said it was returning the first dir with a _parent_ not named `node_modules`. Corrected comment.
