### PR TITLE
Remove traling option in jshintrc

### DIFF
--- a/files/jshintrc
+++ b/files/jshintrc
@@ -5,6 +5,5 @@
   "latedef": true,
   "quotmark": true,
   "undef": true,
-  "unused": true,
-  "trailing": true
+  "unused": true
 }


### PR DESCRIPTION
Remove `trailing` option since it was removed in [`jshint@2.5.0`](https://github.com/jshint/jshint/releases/tag/2.5.0).
