### PR TITLE
Hook throws on stdout buffer overflow

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -48,7 +48,7 @@ function runCmd(name, done) {
     }
 
     var cmd = (process.platform === 'win32' ? 'cmd /c ' : 'sh -c ') + JSON.stringify(scripts[name]);
-    exec(cmd, { cwd: projectRoot, env: env }, function (err, stdout, stderr) {
+    exec(cmd, { cwd: projectRoot, env: env, maxBuffer: 1024*1024 }, function (err, stdout, stderr) {
         if (err) {
             console.log(fail);
             console.log(stdout);


### PR DESCRIPTION
When there's a huge stdout (more than default 200K) hook throws and doesn't allow to make commit.
Seems like 1M should be enough :)
